### PR TITLE
Remove example logging output file as it is never longer needed

### DIFF
--- a/pkg/logger/example.txt
+++ b/pkg/logger/example.txt
@@ -1,1 +1,0 @@
-This goes to file and memory, with logging!


### PR DESCRIPTION
This pull request includes a minor change to the `pkg/logger/example.txt` file. The change removes a line of text, likely to clean up or update the example file.