### PR TITLE
fix: correct pointer usage for BaseCamera in SerialCamera struct

### DIFF
--- a/pkg/camera/serial.go
+++ b/pkg/camera/serial.go
@@ -30,7 +30,7 @@ var (
 
 // SerialCamera represents a camera connected via serial port.
 type SerialCamera struct {
-	BaseCamera
+	*BaseCamera
 	port        serial.Port
 	startSeq    []byte
 	endSeq      []byte
@@ -53,7 +53,7 @@ func NewSerialCamera(typ Type, portName string, baudRate int, compression int) (
 	})
 
 	sc := &SerialCamera{
-		BaseCamera:  base,
+		BaseCamera:  &base,
 		startSeq:    DefaultStartSeq,
 		endSeq:      DefaultEndSeq,
 		imageWidth:  DefaultImageWidth,


### PR DESCRIPTION
This pull request refactors the `SerialCamera` struct in `pkg/camera/serial.go` to use a pointer to `BaseCamera` instead of embedding it directly. This change ensures consistent behavior when modifying the `BaseCamera` instance and aligns with Go best practices for struct embedding.

### Refactoring in `SerialCamera` struct:

* Changed the `BaseCamera` field in the `SerialCamera` struct to a pointer (`*BaseCamera`) to allow shared modifications and avoid copying the struct. (`[pkg/camera/serial.goL33-R33](diffhunk://#diff-6a0c3ccd2cf6e4cfe9cf762fd4b06da3faa150e50cb297e48d0a08d6f6113ca2L33-R33)`)
* Updated the `NewSerialCamera` constructor to assign a pointer to `BaseCamera` when initializing a `SerialCamera` instance. (`[pkg/camera/serial.goL56-R56](diffhunk://#diff-6a0c3ccd2cf6e4cfe9cf762fd4b06da3faa150e50cb297e48d0a08d6f6113ca2L56-R56)`)